### PR TITLE
Prevent import of existing or duplicate resources (resolve #27)

### DIFF
--- a/includes/classes/Importer.php
+++ b/includes/classes/Importer.php
@@ -424,7 +424,9 @@ class Importer {
 				)
 			);
 
-			return;
+			do_action( 'resource_importer.process_skipped.resource', $data ); // @codingStandardsIgnoreLine
+
+			return false;
 		}
 
 		// Does this post already exist?

--- a/templates/footer.php
+++ b/templates/footer.php
@@ -4,6 +4,7 @@
  *
  * @package LearningCommonsImporter
  */
+
 ?>
 
 <?php do_action( 'learning_commons_importer_ui_footer' ); ?>

--- a/templates/select-options.php
+++ b/templates/select-options.php
@@ -13,7 +13,7 @@ $this->render_header();
 <div class="welcome-panel">
 	<div class="welcome-panel-content">
 		<h2><?php esc_html_e( 'Step 2: Import Settings', 'learning-commons-importer' ); ?></h2>
-		<p><?php esc_html_e( 'Your import is almost ready to go. Before your content is imported, pick exactly how you want your data imported.', 'learning-commons-importer' ); ?></p>
+		<p><?php esc_html_e( 'Your import is almost ready to go.', 'learning-commons-importer' ); ?></p>
 
 		<div class="welcome-panel-column-container">
 			<div class="welcome-panel-column">


### PR DESCRIPTION
* [x] I've read the [guidelines for Contributing to the Platform Co-op Toolkit](https://github.com/platform-coop-toolkit/.github/blob/master/CONTRIBUTING.md)
* [x] This isn't a duplicate of an existing pull request

## Description

This pull request resolves #27 by checking resource titles against existing resources and other resource titles within the current batch. I identified nine duplicates in the spreadsheet while testing.

## Steps to test

1. Import the spreadsheet of resources.
2. Import the spreadsheet of resources again.

**Expected behavior:** No duplication.

## Additional information

Not applicable.

## Related issues

- Resolves #27
