### PR TITLE
Consolidates publication date for querying purposes

### DIFF
--- a/includes/classes/Importer.php
+++ b/includes/classes/Importer.php
@@ -310,6 +310,10 @@ class Importer {
 								'key'   => 'lc_resource_publication_year',
 								'value' => absint( $val ),
 							];
+							$meta[] = [
+								'key'   => 'lc_resource_publication_date',
+								'value' => absint( $val ),
+							];
 							break;
 						case 'Author':
 							$val = explode( '; ', $val );
@@ -365,6 +369,10 @@ class Importer {
 								$meta[] = [
 									'key'   => 'lc_resource_publication_day',
 									'value' => Date::excelToDateTimeObject( $val )->format( 'd' ),
+								];
+								$meta[] = [
+									'key'   => 'lc_resource_publication_date',
+									'value' => Date::excelToDateTimeObject( $val )->format( 'Y-m-d' ),
 								];
 							}
 							break;


### PR DESCRIPTION
* [x] I've read the [guidelines for Contributing to the Platform Co-op Toolkit](https://github.com/platform-coop-toolkit/.github/blob/master/CONTRIBUTING.md)
* [x] This isn't a duplicate of an existing pull request

## Description

We need to be able to sort resources by publication date, so this PR consolidates year/month/day into a supplementary publication date field (which will not be directly editable).

## Steps to test

1. Import resources.

**Expected behavior:** Publication date field is populated.

## Additional information

Not applicable.

## Related issues

Not applicable.
